### PR TITLE
feat: ssh-key

### DIFF
--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.IMPAKTFULL_GITHUB_PAT }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
           ref: ${{ github.ref }}
       - name: Setup Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow file `.github/workflows/create_tag.yml`. The change updates the authentication method used for checking out the source code.

* [`.github/workflows/create_tag.yml`](diffhunk://#diff-df83a34d3c3213aa57af4b2448fc8b2323ec525f723fdec04ff2c2c9b4f5b04bL16-R16): Replaced the `token` parameter with `ssh-key` for the `actions/checkout@v2` action to use the `DEPLOY_KEY` secret instead of `IMPAKTFULL_GITHUB_PAT`.